### PR TITLE
Django 1.8 support.  This breaks Django 1.7 support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ django-mysql-pymysql
 
 This is a Django database backend for MySQL, using the PyMySQL database adapter. It is intended to be a drop-in replacement for the built-in MySQLdb backend, and leverages quite a bit of its code.
 
-It is currently experimental, and has been tested with Django 1.7.
+It is currently experimental, and has been tested with Django 1.8.
 
 
 Requirements

--- a/src/mysql_pymysql/base.py
+++ b/src/mysql_pymysql/base.py
@@ -36,8 +36,10 @@ except ImportError:
 
 from django.conf import settings
 from django.db import utils
-from django.db.backends import (utils as backend_utils, BaseDatabaseFeatures,
-    BaseDatabaseOperations, BaseDatabaseWrapper)
+from django.db.backends.base.features import BaseDatabaseFeatures
+from django.db.backends.base.operations import BaseDatabaseOperations
+from django.db.backends.base.base import BaseDatabaseWrapper
+from django.db.backends import utils as backend_utils
 from django.db.backends.mysql.client import DatabaseClient
 from django.db.backends.mysql.creation import DatabaseCreation
 from mysql_pymysql.introspection import DatabaseIntrospection
@@ -437,6 +439,37 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         'istartswith': 'LIKE %s',
         'iendswith': 'LIKE %s',
     }
+
+    data_types = {
+        'AutoField': 'integer AUTO_INCREMENT',
+        'BinaryField': 'longblob',
+        'BooleanField': 'bool',
+        'CharField': 'varchar(%(max_length)s)',
+        'CommaSeparatedIntegerField': 'varchar(%(max_length)s)',
+        'DateField': 'date',
+        'DateTimeField': 'datetime',
+        'DecimalField': 'numeric(%(max_digits)s, %(decimal_places)s)',
+        'DurationField': 'bigint',
+        'FileField': 'varchar(%(max_length)s)',
+        'FilePathField': 'varchar(%(max_length)s)',
+        'FloatField': 'double precision',
+        'IntegerField': 'integer',
+        'BigIntegerField': 'bigint',
+        'IPAddressField': 'char(15)',
+        'GenericIPAddressField': 'char(39)',
+        'NullBooleanField': 'bool',
+        'OneToOneField': 'integer',
+        'PositiveIntegerField': 'integer UNSIGNED',
+        'PositiveSmallIntegerField': 'smallint UNSIGNED',
+        'SlugField': 'varchar(%(max_length)s)',
+        'SmallIntegerField': 'smallint',
+        'TextField': 'longtext',
+        'TimeField': 'time',
+        'UUIDField': 'char(32)',
+        'DateTimeField': 'datetime(6)',
+        'TimeField': 'time(6)',
+    }
+
 
     Database = Database
 

--- a/src/mysql_pymysql/introspection.py
+++ b/src/mysql_pymysql/introspection.py
@@ -1,4 +1,4 @@
-from django.db.backends import BaseDatabaseIntrospection
+from django.db.backends.base.introspection import BaseDatabaseIntrospection, TableInfo
 from pymysql import ProgrammingError, OperationalError
 from pymysql.constants import FIELD_TYPE
 import re
@@ -30,9 +30,12 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
     }
 
     def get_table_list(self, cursor):
-        "Returns a list of table names in the current database."
-        cursor.execute("SHOW TABLES")
-        return [row[0] for row in cursor.fetchall()]
+        """
+        Returns a list of table and view names in the current database.
+        """
+        cursor.execute("SHOW FULL TABLES")
+        return [TableInfo(row[0], {'BASE TABLE': 't', 'VIEW': 'v'}.get(row[1]))
+                for row in cursor.fetchall()]
 
     def get_table_description(self, cursor, table_name):
         "Returns a description of the table, with the DB-API cursor.description interface."

--- a/src/mysql_pymysql/schema.py
+++ b/src/mysql_pymysql/schema.py
@@ -1,4 +1,4 @@
-from django.db.backends.schema import BaseDatabaseSchemaEditor
+from django.db.backends.base.schema import BaseDatabaseSchemaEditor
 from django.db.models import NOT_PROVIDED
 
 


### PR DESCRIPTION
Lock to older version if you have Django 1.7

https://docs.djangoproject.com/en/1.8/releases/1.8/#database-backend-api covers the Django changes we had to adapt to.  Mostly
- new import paths for some stuff
- define data_types for wrapper
- adjust get_table_list to match what is expected, see https://github.com/django/django/commit/b8cdc7dcc3fc6897fb2a75f90023f5c67aad327f
- update README reflect that we only support Django 1.8 now

@kokon 
